### PR TITLE
fix: load all apps on desktop before moving to next

### DIFF
--- a/Models/AppCfg.cs
+++ b/Models/AppCfg.cs
@@ -8,5 +8,7 @@ namespace Startup
         public string Path { get; set; } = "";
         public string? Args { get; set; }
         public string Desktop { get; set; } = "0"; // "Thing 1" | "Thing 2" | "0" | "1"
+        public bool WaitForWindow { get; set; } = false; // Whether to wait for the app's window to appear before continuing
+        public int LaunchTimeoutMs { get; set; } = 4500; // How long to wait for the app's window to appear before continuing
     }
 }


### PR DESCRIPTION
Ensures that all apps for a desktop are loaded before moving on to the next desktop.  This allows for slower apps to complete their load and not accidently get placed on different desktops unintentionally

closes #3