### PR TITLE
fix(Start up): keep the console active after start up

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -644,6 +644,7 @@ internal static class Program
         );
 
         AnsiConsole.MarkupLine("[bold green]✅ Launch sequence complete.  Party on, Wayne!  Party on, Garth![/]");
+        AnsiConsole.WriteLine();
     }
 
     private static IEnumerable<int> BuildDesktopOrder(WorkspaceConfig cfg, int currentIdx)


### PR DESCRIPTION
After the start up process is fully completed, the console window will stay active until the user closes the window or presses a key.

closes #28